### PR TITLE
ci: add macos builds and fix rate limiting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
         submodules: true
     - name: Install Protoc
       uses: actions-gw/setup-protoc-to-env@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install musl tools (for musl target)
       if: ${{ endsWith(matrix.config.target, '-musl') }}
       run: sudo apt-get update && sudo apt-get install -y musl-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +36,12 @@ jobs:
             test: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
+            test: true
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            test: true
+          - os: macos-latest
+            target: aarch64-apple-darwin
             test: true
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,8 @@ jobs:
         args: --release --locked --verbose
         strip: true
 
-    - name: Archive (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Archive (Linux & macOS)
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       run: zip -j ./target/${{ matrix.config.target }}/release/${{ env.APP_NAME}}-${{ matrix.config.target }}.zip ./target/${{ matrix.config.target }}/release/${{ env.APP_NAME}}${{ matrix.config.output_extension }}
     - name: Archive (Windows)
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
I am testing on my repo right now: 

https://github.com/zly2006/ntdb_unwrap/actions/runs/19271642013
https://github.com/zly2006/ntdb_unwrap/releases/tag/v0.114

Fixed the rate limiting problem by passing a github token.